### PR TITLE
Various Utilities

### DIFF
--- a/mily/utils.py
+++ b/mily/utils.py
@@ -27,6 +27,32 @@ def clear_layout(layout):
             clear_layout(child.layout())
 
 
+def reload_widget_stylesheet(widget, cascade=False):
+    """
+    Reload the stylesheet of a QWidget
+
+    When a ``pyqtProperty`` is updated, a widget does not automatically reapply
+    its stylesheet. This is an issue if a stylesheet is conditionally applied
+    based on the ``pyqtProperty`` value. This method handles reapplying the
+    existing stylesheet to guarantee that interface is up-to-date with any
+    changes to the contained properties
+
+    Parameters
+    ----------
+    widget: QWidget
+
+    cascade: bool, optional
+        Any child of the provided widget will also re-update its stylesheet
+    """
+    widget.style().unpolish(widget)
+    widget.style().polish(widget)
+    widget.update()
+    if cascade:
+        for child in widget.children():
+            if isinstance(child, QWidget):
+                reload_widget_stylesheet(child, cascade=True)
+
+
 def raise_to_operator(exc):
     """
     Utility function to show a Python Exception in QMessageBox

--- a/mily/utils.py
+++ b/mily/utils.py
@@ -53,7 +53,7 @@ def reload_widget_stylesheet(widget, cascade=False):
                 reload_widget_stylesheet(child, cascade=True)
 
 
-def raise_to_operator(exc):
+def raise_to_operator(exc, execute=True):
     """
     Utility function to show a Python Exception in QMessageBox
 
@@ -64,6 +64,9 @@ def raise_to_operator(exc):
     Parameters
     ----------
     exc: Exception
+
+    execute: bool, optional
+        Whether to execute the QMessageBox
     """
     # Assemble QMessageBox with Exception details
     err_msg = QMessageBox()
@@ -75,6 +78,7 @@ def raise_to_operator(exc):
     traceback.print_tb(exc.__traceback__, file=handle)
     handle.seek(0)
     err_msg.setDetailedText(handle.read())
-    # Execute
-    err_msg.exec_()
+    if execute:
+        # Execute
+        err_msg.exec_()
     return err_msg

--- a/mily/utils.py
+++ b/mily/utils.py
@@ -74,10 +74,10 @@ def raise_to_operator(exc, execute=True):
     err_msg.setWindowTitle(type(exc).__name__)
     err_msg.setIcon(QMessageBox.Critical)
     # Format traceback as detailed text
-    handle = io.StringIO()
-    traceback.print_tb(exc.__traceback__, file=handle)
-    handle.seek(0)
-    err_msg.setDetailedText(handle.read())
+    with io.StringIO() as handle:
+        traceback.print_tb(exc.__traceback__, file=handle)
+        handle.seek(0)
+        err_msg.setDetailedText(handle.read())
     if execute:
         # Execute
         err_msg.exec_()

--- a/mily/utils.py
+++ b/mily/utils.py
@@ -1,0 +1,23 @@
+"""
+Various Qt Utilities
+"""
+
+
+def clear_layout(layout):
+    """
+    Clear a QLayout
+
+    This method acts recursively, clearing any child layouts that may be
+    contained within the layout itself. All discovered widgets are marked for
+    deletion.
+
+    Parameters
+    ----------
+    layout : QLayout
+    """
+    while layout.count():
+        child = layout.takeAt(0)
+        if child.widget():
+            child.widget().deleteLater()
+        elif child.layout():
+            clear_layout(child.layout())

--- a/mily/utils.py
+++ b/mily/utils.py
@@ -1,6 +1,10 @@
 """
 Various Qt Utilities
 """
+import io
+import traceback
+
+from qtpy.QtWidgets import QWidget, QMessageBox
 
 
 def clear_layout(layout):
@@ -21,3 +25,30 @@ def clear_layout(layout):
             child.widget().deleteLater()
         elif child.layout():
             clear_layout(child.layout())
+
+
+def raise_to_operator(exc):
+    """
+    Utility function to show a Python Exception in QMessageBox
+
+    The type and representation of the Exception are shown in a pop-up
+    QMessageBox. The entire traceback is available via a drop-down detailed
+    text box in the QMessageBox
+
+    Parameters
+    ----------
+    exc: Exception
+    """
+    # Assemble QMessageBox with Exception details
+    err_msg = QMessageBox()
+    err_msg.setText(f'{exc.__class__.__name__}: {exc}')
+    err_msg.setWindowTitle(type(exc).__name__)
+    err_msg.setIcon(QMessageBox.Critical)
+    # Format traceback as detailed text
+    handle = io.StringIO()
+    traceback.print_tb(exc.__traceback__, file=handle)
+    handle.seek(0)
+    err_msg.setDetailedText(handle.read())
+    # Execute
+    err_msg.exec_()
+    return err_msg

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ codecov
 coverage
 flake8
 pytest
+pytest-qt
 sphinx
 # These are dependencies of various sphinx extensions for documentation.
 ipython

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+from qtpy.QtWidgets import QMessageBox
+
+from mily.utils import raise_to_operator
+
+
+def test_raise_to_operator_msg(monkeypatch, qtbot):
+
+    monkeypatch.setattr(QMessageBox, 'exec_', lambda x: 1)
+    exc_dialog = None
+    try:
+        1/0
+    except ZeroDivisionError as exc:
+        exc_dialog = raise_to_operator(exc)
+
+    qtbot.addWidget(exc_dialog)
+    assert exc_dialog is not None
+    assert 'ZeroDivisionError' in exc_dialog.text()


### PR DESCRIPTION
Here here! Collaboration!

Three utility functions I find helpful.

1. Clearing a layout and deleting the child widgets is a pretty common task, frustrating there isn't a method built-in to Qt.

2. If you define your own `pyqtProperty` and expect people to include it in a conditional statement as part of Qt StyleSheet. You need to refresh the stylesheet on the widget. `refresh_stylesheet` contains this cryptic yet boilerplate code. This is need in PyDM for things like

```css
PyDMWidget[alarm_severity='0'] {
...
}
```
3. In these Qt GUIs I found a pattern where you never want your Python Exceptions to bubble all the way up and crash your application, but you want your operator to know when they did something wrong. I use this `raise_to_operator` utility a lot to make sure that user errors are expressed properly. 

![raise_to_operator](https://user-images.githubusercontent.com/25753048/53279016-065fae80-36c2-11e9-99ac-5340835951b1.gif)