### PR TITLE
minimally useful table interface widget

### DIFF
--- a/mily/table_interface.py
+++ b/mily/table_interface.py
@@ -1,3 +1,4 @@
+from collection import OrderedDict
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QTableView, QWidget, QLabel, QStyledItemDelegate,
@@ -344,14 +345,14 @@ class MTableInterfaceWidget(QWidget):
         The name of the widget, stored on self._name
     *args/**kwargs : various
         args and kwargs to be passed to ``PyQt5.QtWidgets.QWidget``.
-    prefix_editor_map : dict, optional
-        A dictionary that maps parameter names to editor widgets, for
+    prefix_editor_map : OrderedDict, optional
+        An OrderedDict that maps parameter names to editor widgets, for
         parameters that are to be displayed above the table.
-    table_editor_map : dict, optional
-        A dictionary that maps column names to editor widgets, for
+    table_editor_map : OrderedDict, optional
+        An OrderedDict that maps column names to editor widgets, for
         parameters that are to be displayed in the table.
-    suffix_editor_map : dict, optional
-        A dictionary that maps parameter names to editor widgets, for
+    suffix_editor_map : OrderedDict, optional
+        An OrderedDict that maps parameter names to editor widgets, for
         parameters that are to be displayed below the table.
     default_parameters : [dicts]
         A list of dicts following the structure defined above that contain
@@ -367,8 +368,10 @@ class MTableInterfaceWidget(QWidget):
     '''
 
     def __init__(self, name, *args, delegate=MTableItemDelegate,
-                 prefix_editor_map={}, table_editor_map={},
-                 suffix_editor_map={}, default_parameters=[],
+                 prefix_editor_map=OrderedDict({}),
+                 table_editor_map=OrderedDict({}),
+                 suffix_editor_map=OrderedDict({}),
+                 default_parameters=[],
                  update_coupled_parameters=None, title='Default Title',
                  geometry=(100, 100, 800, 300), mainLayoutString=None,
                  **kwargs):
@@ -710,7 +713,8 @@ class MTableInterfaceWidget(QWidget):
         ``self.tableView.model().update_coupled_parameters`` to ensure that
         the new arrangment is ok, it will update any values that are not.
         '''
-        if self.table_editor_map:  # check that a table actually exists
+        if (self.table_editor_map and
+            self.tableView.model().update_coupled_parameters):
             # step through each row and check it
             model = self.tableView.model()
             column_names = list(self.table_editor_map.keys())

--- a/mily/table_interface.py
+++ b/mily/table_interface.py
@@ -351,14 +351,16 @@ class MTableInterfaceWidget(QWidget):
                 self.prefixLayout.addLayout(vstacked_label(name, widget))
             self.mainLayout.addLayout(self.prefixLayout)
 
-        # create the table view
-        self.tableView = MTableInterfaceView(self, self._name + '_view',
-                                             editor_map=self.table_editor_map,
-                                             delegate=delegate)
-        self.mainLayout.addWidget(self.tableView)
+        # if any table parameters are specifed in table_editor_map add them
+        if self.table_editor_map:
+            # create the table view
+            self.tableView = MTableInterfaceView(
+                self, self._name + '_view', editor_map=self.table_editor_map,
+                delegate=delegate)
+            self.mainLayout.addWidget(self.tableView)
 
-        # enable sorting of the table
-        self.tableView.setSortingEnabled(True)
+            # enable sorting of the table
+            self.tableView.setSortingEnabled(True)
 
         # if any global parameters are specifed in suffix_editor_map add them
         if self.suffix_editor_map:
@@ -372,35 +374,35 @@ class MTableInterfaceWidget(QWidget):
         # load the default_entries
         self.set_default(self.default_parameters)
 
-        # create and add buttons
+        # create and add table buttons if any table values exist
         self.btnLayout = QHBoxLayout()
+        if self.table_editor_map:
+            self.addRowBtn = QPushButton('+', self)
+            self.addRowBtn.setToolTip('inserts a blank row(s) after the '
+                                      'selected row(s)')
+            self.addRowBtn.clicked.connect(self._addRow)
+            self.btnLayout.addWidget(self.addRowBtn)
 
-        self.addRowBtn = QPushButton('+', self)
-        self.addRowBtn.setToolTip('inserts a blank row(s) after the selected '
-                                  'row(s)')
-        self.addRowBtn.clicked.connect(self._addRow)
-        self.btnLayout.addWidget(self.addRowBtn)
+            self.delRowBtn = QPushButton('-', self)
+            self.delRowBtn.setToolTip('deletes the selected row(s)')
+            self.delRowBtn.clicked.connect(self._delRow)
+            self.btnLayout.addWidget(self.delRowBtn)
 
-        self.delRowBtn = QPushButton('-', self)
-        self.delRowBtn.setToolTip('deletes the selected row(s)')
-        self.delRowBtn.clicked.connect(self._delRow)
-        self.btnLayout.addWidget(self.delRowBtn)
+            self.upRowBtn = QPushButton('up', self)
+            self.upRowBtn.setToolTip('move currently selected row down')
+            self.upRowBtn.clicked.connect(self._upRow)
+            self.btnLayout.addWidget(self.upRowBtn)
 
-        self.upRowBtn = QPushButton('up', self)
-        self.upRowBtn.setToolTip('move currently selected row down')
-        self.upRowBtn.clicked.connect(self._upRow)
-        self.btnLayout.addWidget(self.upRowBtn)
+            self.downRowBtn = QPushButton('down', self)
+            self.downRowBtn.setToolTip('move currently selected row down')
+            self.downRowBtn.clicked.connect(self._downRow)
+            self.btnLayout.addWidget(self.downRowBtn)
 
-        self.downRowBtn = QPushButton('down', self)
-        self.downRowBtn.setToolTip('move currently selected row down')
-        self.downRowBtn.clicked.connect(self._downRow)
-        self.btnLayout.addWidget(self.downRowBtn)
-
-        self.duplicateRowBtn = QPushButton('duplicate', self)
-        self.duplicateRowBtn.setToolTip('inserts a duplicate of the selected '
-                                        'row(s)')
-        self.duplicateRowBtn.clicked.connect(self._duplicateRow)
-        self.btnLayout.addWidget(self.duplicateRowBtn)
+            self.duplicateRowBtn = QPushButton('duplicate', self)
+            self.duplicateRowBtn.setToolTip('inserts a duplicate of the '
+                                            'selected row(s)')
+            self.duplicateRowBtn.clicked.connect(self._duplicateRow)
+            self.btnLayout.addWidget(self.duplicateRowBtn)
 
         # create the layout and add the widgets
         self.mainLayout.addLayout(self.btnLayout)
@@ -436,7 +438,8 @@ class MTableInterfaceWidget(QWidget):
                 editor.set_default(value)
 
         # ask self.tableView to set other parameters
-        self.tableView.set_default(parameters)
+        if self.table_editor_map:
+            self.tableView.set_default(parameters)
 
     def get_parameters(self):
         '''Return the entire data from the table.
@@ -452,7 +455,10 @@ class MTableInterfaceWidget(QWidget):
         parameters.append(self.get_prefix_parameters()[self._name])
 
         # add table dicts
-        view_list = self.tableView.get_parameters()[self.tableView._name]
+        if self.table_editor_map:
+            view_list = self.tableView.get_parameters()[self.tableView._name]
+        else:
+            view_list = {}
         parameters.extend(view_list)
 
         # add suffix dict
@@ -503,7 +509,11 @@ class MTableInterfaceWidget(QWidget):
         parameters  : dict
             A dictionary mapping kwargs to values.
         '''
-        params = self.tableView.get_row_parameters(row)[self.tableView._name]
+        if self.table_editor_map:
+            params = self.tableView.get_row_parameters(
+                row)[self.tableView._name]
+        else:
+            params = {}
         return {self._name: params}
 
     def _addRow(self):

--- a/mily/table_interface.py
+++ b/mily/table_interface.py
@@ -184,9 +184,13 @@ class MTableInterfaceView(QTableView):
             row_params = {}
             for column in range(0, model.columnCount()):
                 item = model.item(row, column)
-                row_params[column_names[column]] = (item.data(Qt.DisplayRole))
+                if item:
+                    value = item.data(Qt.DisplayRole)
+                else:
+                    value=None
+                row_params[column_names[column]] = value
             parameters.append(row_params)
-        return(self._name, parameters)
+        return {self._name: parameters}
 
     def set_default(self, parameters):
         '''Sets the default values from 'parameters' to the model
@@ -304,9 +308,7 @@ class MTableInterfaceWidget(QWidget):
 
         # create a QLabel which describes the table
         if not self.mainLayoutString:
-            self.mainLayoutString = (f'Below you can map "labels" to the '
-                                     f'args/ kwargs for the function "'
-                                     f'{self.function.__name__}"')
+            self.mainLayoutString = (f'')
 
         self.mainLabel = QLabel(self.mainLayoutString)
         self.mainLayout.addWidget(self.mainLabel)
@@ -418,20 +420,20 @@ class MTableInterfaceWidget(QWidget):
         # if parameters is None set it to an empty list.
         if not parameters:
             parameters = []
+        else:
+            # extract and set prefix parameters
+            if self.prefix_editor_map:
+                prefix_parameters = parameters.pop(0)
+                for parameter, value in prefix_parameters.items():
+                    editor = getattr(self, parameter)
+                    editor.set_default(value)
 
-        # extract and set prefix parameters
-        if self.prefix_editor_map:
-            prefix_parameters = parameters.pop(0)
-            for parameter, value in prefix_parameters.items():
-                editor = getattr(self, parameter)
-                editor.set_default(value)
-
-        # extract and set suffix parameters
-        if self.suffix_editor_map:
-            suffix_parameters = parameters.pop(-1)
-            for parameter, value in suffix_parameters.items():
-                editor = getattr(self, parameter)
-                editor.set_default(value)
+            # extract and set suffix parameters
+            if self.suffix_editor_map:
+                suffix_parameters = parameters.pop(-1)
+                for parameter, value in suffix_parameters.items():
+                    editor = getattr(self, parameter)
+                    editor.set_default(value)
 
         # ask self.tableView to set other parameters
         self.tableView.set_default(parameters)

--- a/mily/table_interface.py
+++ b/mily/table_interface.py
@@ -14,7 +14,7 @@ class MTableItemDelegate(QStyledItemDelegate):
     ``get_parameters`` and ``set_default`` methods for reading/writing
     to/from the editor widgets. It has a ``self.editor_map`` attribute that
     maps the column names to editor widgets. It also has a custom method for
-    ``self.createEditor`` that uses ``self. editor_map`` and returns the
+    ``self.createEditor`` that uses ``self.editor_map`` and returns the
     correct editor on request. If editor_map is empty it uses an ``MText``
     widget for all columns. It also enforces the inclusion of a parent
     attribute (something that is optional in the ``QStyledItemDelegate``) and
@@ -27,16 +27,16 @@ class MTableItemDelegate(QStyledItemDelegate):
         self.editor_map = editor_map
 
     def displayText(self, value, locale):
-        '''converts the value of the editor to a display string.
+        '''Converts the value of the editor to a display string.
 
         This method is called whenever the associated model value is updated,
         and updates the associated TableView with the returned str_val for
-        display. It is written such that it will ind the best str to asociate
+        display. It is written such that it will find the best str to associate
         with the object, and will recursively change dict and list keys/items.
         '''
 
         def _get_display_str(value):
-            '''recursively find a list of attr names for a DisplayText.
+            '''Recursively find a list of attr names for a DisplayText.
 
             This checks a number of attr names to see if any are present and
             can be used to give a displayText value. Otherwise it returns the
@@ -45,7 +45,7 @@ class MTableItemDelegate(QStyledItemDelegate):
             after setting displayText's for each key+value (for dicts) or item
             (for lists).
             '''
-            if isinstance(value, list):  # recuresively treat lists
+            if isinstance(value, list):  # recursively treat lists
                 list_val = []
                 for item in value:
                     list_val.append(_get_display_str(item))
@@ -176,13 +176,13 @@ class MTableInterfaceView(QTableView):
         '''Sets the default values from 'parameters' to the model
 
         Sets the data from 'parameters' to the model, overwriting any existing
-        data in the model.This follows the ``mily.widget`` API.
+        data in the model. This follows the ``mily.widget`` API.
 
         Parameters
         ----------
         parameters : [dicts]
-            List of dicts  with each dict being a row that maps the column
-            header to it's value.
+            List of dicts with each dict being a row that maps the column
+            header to its value.
         '''
         model = self.model()
         # Empty the model.
@@ -352,7 +352,7 @@ class MTableInterfaceWidget(QWidget):
             self.mainLayout.addLayout(self.prefixLayout)
 
         # create the table view
-        self.tableView = MTableInterfaceView(self, self._name+'_view',
+        self.tableView = MTableInterfaceView(self, self._name + '_view',
                                              editor_map=self.table_editor_map,
                                              delegate=delegate)
         self.mainLayout.addWidget(self.tableView)
@@ -376,7 +376,7 @@ class MTableInterfaceWidget(QWidget):
         self.btnLayout = QHBoxLayout()
 
         self.addRowBtn = QPushButton('+', self)
-        self.addRowBtn.setToolTip('inserts a blank row(s) after the selected'
+        self.addRowBtn.setToolTip('inserts a blank row(s) after the selected '
                                   'row(s)')
         self.addRowBtn.clicked.connect(self._addRow)
         self.btnLayout.addWidget(self.addRowBtn)
@@ -416,7 +416,7 @@ class MTableInterfaceWidget(QWidget):
         ----------
         parameters : [dicts]
             List of dicts with each dict being a row that maps the column
-            header to it's value.
+            header to its value.
         '''
 
         # if parameters is None set it to an empty list.
@@ -507,19 +507,19 @@ class MTableInterfaceWidget(QWidget):
         return {self._name: params}
 
     def _addRow(self):
-        '''inserts an empty row after the (last) currently selected row(s)'''
+        '''Inserts an empty row after the (last) currently selected row(s).'''
 
         indices = self.tableView.selectionModel().selectedIndexes()
         rows = [index.row() for index in indices]
         rows.sort(reverse=True)
         if rows:  # add an empty row after the last selected row
-            self.tableView.model().insertRow(rows[0]+1, [])
+            self.tableView.model().insertRow(rows[0] + 1, [])
         else:  # If no rows selected add row at end of table
             end_row = self.tableView.model().rowCount()
             self.tableView.model().insertRow(end_row, [])
 
     def _delRow(self):
-        '''deletes the selected row(s)'''
+        '''Deletes the selected row(s).'''
         indices = self.tableView.selectionModel().selectedIndexes()
         rows = [index.row() for index in indices]
         rows.sort(reverse=True)
@@ -537,7 +537,7 @@ class MTableInterfaceWidget(QWidget):
         if self._check_rows(rows):
             for row in rows:
                 items = self.tableView.model().takeRow(row)
-                self.tableView.model().insertRow(row-1, items)
+                self.tableView.model().insertRow(row - 1, items)
 
     def _downRow(self):
         '''Moves the currently selected row(s) down one.'''
@@ -550,10 +550,10 @@ class MTableInterfaceWidget(QWidget):
         if self._check_rows(rows):
             for row in rows:
                 items = self.tableView.model().takeRow(row)
-                self.tableView.model().insertRow(row+1, items)
+                self.tableView.model().insertRow(row + 1, items)
 
     def _duplicateRow(self):
-        '''duplicates the selected row(s) into the table after the row(s)'''
+        '''Duplicates the selected row(s) into the table after the row(s).'''
 
         # find the selected row(s)
         indices = self.tableView.selectionModel().selectedIndexes()
@@ -564,19 +564,19 @@ class MTableInterfaceWidget(QWidget):
             model = self.tableView.model()
             for row in rows:
                 row_data = []
-                for column in range(0, model.columnCount()):
+                for column in range(model.columnCount()):
                     value = model.item(row, column).data(Qt.DisplayRole)
                     item = QStandardItem()
                     item.setData(value, Qt.DisplayRole)
                     row_data.append(item)
-                model.insertRow(row+1, row_data)
+                model.insertRow(row + 1, row_data)
 
     def _check_rows(self, rows, only_one=False):
         '''Checks how many items are in ``rows`` and alerts user if not right.
 
-        Checks that the number of indices in ``rows``, alerts the user with a
-        popup box if their are no items in ``rows``. Alternatively if the kwarg
-        ``only_one`` is ``True`` also alerts users that to many rows are
+        Checks the number of indices in ``rows``, alerts the user with a
+        popup box if there are no items in ``rows``. Alternatively if the kwarg
+        ``only_one`` is ``True`` also alerts users that too many rows are
         selected. Returns ``True`` if the right number(s) of items are in
         ``rows`` otherwise it returns ``False``.
 
@@ -637,7 +637,7 @@ class MFunctionTableInterfaceWidget(MTableInterfaceWidget):
     Parameters
     ----------
     function : func
-        The function asociated with this table input.
+        The function associated with this table input.
     *args/**kwargs : various
         args and kwargs to be passed to the parent
         ``mily.MTableInterfaceWidget``.

--- a/mily/table_interface.py
+++ b/mily/table_interface.py
@@ -1,0 +1,540 @@
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (QTableView, QWidget, QLabel, QStyledItemDelegate,
+                             QHBoxLayout, QVBoxLayout, QMessageBox,
+                             QPushButton)
+from .widgets import MText
+
+
+class MTableItemDelegate(QStyledItemDelegate):
+    '''A ``QStyledItemDelegate`` for use with MTableInterfaceWidgets.
+
+    This adds custom ``displayText``, ``setEditorData`` and ``setModelData``
+    methods that work with the ``mily.widgets`` API. Namely, using the
+    ``get_parameters`` and ``set_default`` methods for reading/writing
+    to/from the editor widgets. It has a ``self.editor_map`` attribute that
+    maps the column names to editor widgets. It also has a custom method for
+    ``self.createEditor`` that uses ``self. editor_map`` and returns the
+    correct editor on request. If editor_map is empty it uses an ``MText``
+    widget for all columns. It also enforces the inclusion of a parent
+    attribute (something that is optional in the ``QStyledItemDelegate``) and
+    adds an ``_name`` attribute for consistency with the `mily.widgets`` API.
+    '''
+
+    def __init__(self, parent, name, *args, **kwargs):
+        self._name = name
+        super().__init__(*args, parent=parent, **kwargs)
+        self.editor_map = getattr(self.parent(), 'editor_map', {})
+
+    def displayText(self, value, locale):
+        '''converts the value of the editor to a display string.
+
+        This method is called whenever the associated model value is updated,
+        and updates the associated TableView with the returned str_val for
+        display. It is written such that it will ind the best str to asociate
+        with the object, and will recursively change dict and list keys/items.
+        '''
+
+        def _get_display_str(value):
+            '''recursively find a list of attr names for a DisplayText.
+
+            This checks a number of attr names to see if any are present and
+            can be used to give a displayText value. Otherwise it returns the
+            str generated using ``str(value)``. It will recursively search
+            ``dict`` and ``list`` values and return str(dict) or str(list)
+            after setting displayText's for each key+value (for dicts) or item
+            (for lists).
+            '''
+            if isinstance(value, list):  # recuresively treat lists
+                list_val = []
+                for item in value:
+                    list_val.append(_get_display_str(item))
+                str_val = str(list_val).replace('"', '').replace("'", "")
+            elif isinstance(value, dict):  # recursively treat dicts
+                dict_val = {}
+                for key, val in value.items():
+                    dict_val[_get_display_str(key)] = _get_display_str(val)
+                str_val = str(dict_val).replace('"', '').replace("'", "")
+            else:  # check individual values
+                # Check a list of attrs that can return displayText values.
+                for attr in ['name', '_name', '__name__']:
+                    str_val = getattr(value, attr, None)
+                    if str_val:
+                        break
+                # If none of the above worked
+                if not str_val:
+                    str_val = str(value)
+
+            return str_val
+
+        return _get_display_str(value)
+
+    def setEditorData(self, editor, index):
+        '''Sets the model data to the editor.
+
+        This method is called whenever the editor is opened and sets the
+        current value of the editor to that in the model. The change here is to
+        use the ``mily.widget`` API ``editor.set_default(value)`` method. It
+        also ensures that data associated with the "display" role in the model
+        is used, which leads to a consistent approach with the
+        ``self.setModelData(...)`` method.
+        '''
+        row = index.row()
+        column = index.column()
+        try:
+            value = index.model().item(row, column).data(Qt.DisplayRole)
+        except AttributeError:
+            value = None
+        editor.set_default(value)
+        # resize the table to the editors size
+        editor.parent().parent().resizeColumnsToContents()
+
+    def setModelData(self, editor, model, index):
+        '''Sets the editor data to the model.
+
+        This method is called whenever the editor is closed _and_ a change has
+        been made to the editor value. The change here is to ensure the use of
+        the ``mily.widget`` API ``editor.get_parameter()`` method to extract
+        the data from the editor. It then writes the data to the model,
+        associating it with the "display" role for consistency with the
+        ``self.setEditorData(...)`` method.
+        '''
+        model.setData(index, editor.get_parameters()[editor._name],
+                      Qt.DisplayRole)
+        # resize the table to the size of the display text
+        editor.parent().parent().resizeColumnsToContents()
+        editor.parent().parent().resizeRowsToContents()
+
+    def createEditor(self, parent, option, index):
+        '''Creates the editor based on ``self.editor_map``.
+
+        This method is whenever a user double clicks on a cell in order to edit
+        its value. Based on the 'index' argument it works out which key in the
+        ``self.editor_map`` dictionary relates to the cell to be edited, and
+        creates the editor based on the type defined by the value for that key.
+        '''
+        column_name = list(self.editor_map.keys())[index.column()]
+
+        editor = self.editor_map.get(column_name, MText)(column_name,
+                                                         parent=parent)
+
+        if editor:
+            # ensure the editors background is opaque
+            editor.setAutoFillBackground(True)
+            # resize the table cell to fit the editor
+            editor.setMinimumWidth(80)
+            editor.parent().parent().setRowHeight(index.row(),
+                                                  editor.height())
+            editor.parent().parent().setColumnWidth(index.column(),
+                                                    editor.width())
+
+        return editor
+
+
+class MTableInterfaceView(QTableView):
+    '''Creates a table view and model for an ``MTableInterfaceWidget``.
+
+    This creates a custom QTableView and sets some display options that are
+    common to ``MTableInterfaceWidget`` tables. It also creates and sets the
+    model and the delegate to be used in conjunction with this view.
+
+    Parameters:
+    *args/**kwargs : various
+        args and kwargs to be passed to ``PyQt5.QtWidgets.QTableView``.
+    delegate : QitemDelegate, optional
+        The ``PyQt5.QItemDelegate`` to be associated with the class, default is
+        the ``MTableItemDelegate``.
+    model : QStandardItemModel, optional
+        The ``PyQt5.QtGui.QStandardItemModel`` to be associated with the
+        class, the default is ``PyQt5.QtGui.QStandardItemModel.
+    '''
+
+    def __init__(self, parent, name, *args, delegate=MTableItemDelegate,
+                 model=QStandardItemModel, **kwargs):
+        self._name = name
+        super().__init__(*args, parent=parent, **kwargs)
+        self.editor_map = getattr(self.parent(), 'editor_map', {})
+        # Apply some style options
+        self.horizontalHeader().setDefaultAlignment(Qt.AlignHCenter)
+        self.setAlternatingRowColors(True)
+        # set the table delegate
+        self.setItemDelegate(delegate(self, self.parent()._name+'_model'))
+        # set the model and set column headers from editor_map if possible
+        self.setModel(model(self))
+        if self.editor_map:
+            column_names = list(self.editor_map.keys())
+            self.model().setHorizontalHeaderLabels(column_names)
+        # resize the table rows/columns to fit the displayText sizes
+        self.resizeColumnsToContents()
+        self.resizeRowsToContents()
+        # resize the table to fit the displayText on editor close
+        self.itemDelegate().closeEditor.connect(self.resizeColumnsToContents)
+        self.itemDelegate().closeEditor.connect(self.resizeRowsToContents)
+
+    def get_parameters(self):
+        '''Return the entire data from the table.
+
+        Returns the entire table data as a list of dicts, with each dict being
+        a row that maps the column header to it's value. This follows the
+        ``mily.widget`` API.
+        '''
+        column_names = list(self.editor_map.keys())
+        model = self.model()
+        parameters = []
+        for row in range(0, model.rowCount()):
+            row_params = {}
+            for column in range(0, model.columnCount()):
+                item = model.item(row, column)
+                row_params[column_names[column]] = (item.data(Qt.DisplayRole))
+            parameters.append(row_params)
+        return(self._name, parameters)
+
+    def set_default(self, parameters):
+        '''Sets the default values from 'parameters' to the model
+
+        Sets the data from 'parameters' to the model, overwriting any existing
+        data in the model.This follows the ``mily.widget`` API.
+
+        Parameters
+        ----------
+        parameters : [dicts]
+            List of dicts  with each dict being a row that maps the column
+            header to it's value.
+        '''
+        model = self.model()
+        # Empty the model.
+        model.removeRows(0, model.rowCount())
+        # Add the new data to the model.
+        for row_params in parameters:
+            row_data = []
+            # for each column in the model check if a default is given
+            for column in range(0, model.columnCount()):
+                header_item = model.horizontalHeaderItem(column)
+                header = header_item.text()
+                item = QStandardItem()
+                value = row_params.get(header, None)
+                item.setData(value, Qt.DisplayRole)
+                row_data.append(item)
+            model.appendRow(row_data)
+
+
+class MTableInterfaceWidget(QWidget):
+    '''Table like interface widget based on the ``mily`` API.
+
+    This widget allows a 'label' string to be associated with a set of
+    args/kwargs for a function. The 'label' and associated args/kwargs are
+    defined in rows in a ``QTableWidget``, and can be updated directly in the
+    table. In addition to the table there are a number of buttons on the widget
+    for modifying the rows as a whole. They are:
+        +: adds a new row after the last selected row (or last row if none
+            selected) ensuring that it contains a unique label.
+        -: deletes the selected row(s).
+        up: moves the selected row(s) up
+        down: moves the selected row(s) down
+
+    Parameters
+    ----------
+    function : func
+        The function asociated with this table input.
+    *args/**kwargs : various
+        args and kwargs to be passed to ``PyQt5.QtWidgets.QWidget``.
+    title : str
+        The title to give the widget.
+    label_header : str
+        The header to use for the label column in the table.
+    geometry : tuple
+        The location and size of the widget given as a tuple with the values:
+        ``(left, top, width, height)``.
+    '''
+
+    # A list of dicts mapping column names to default values, each dict is a
+    # new row.
+    default_rows = []
+
+    def __init__(self, function, name, *args, delegate=MTableItemDelegate,
+                 title='Default Title', label_header='label',
+                 geometry=(100, 100, 800, 300), mainLayoutString=None,
+                 **kwargs):
+        super().__init__()
+        self.function = function
+        self._name = name
+        self.title = title
+        self.label_header = label_header
+        self.geometry = geometry
+        self.mainLayoutString = mainLayoutString
+        # if a child class has not defined editor map define it.
+        if not hasattr(self, 'editor_map'):
+            self.editor_map = {}
+        self._initUI(delegate)
+
+    def _initUI(self, delegate):
+
+        # set the title, location and size of the Widget
+        self.setWindowTitle(self.title)
+        self.setGeometry(*self.geometry)
+
+        # create a QLabel which describes the table
+        if not self.mainLayoutString:
+            self.mainLayoutString = (f'Below you can map "labels" to the '
+                                     f'args/ kwargs for the function "'
+                                     f'{self.function.__name__}"')
+
+        self.mainLabel = QLabel(self.mainLayoutString)
+
+        # create the table widget
+        self.tableView = MTableInterfaceView(self, self._name+'_view',
+                                             delegate=delegate)
+        # enable sorting of the table
+        self.tableView.setSortingEnabled(True)
+
+        # load the default_entries and resize the table columns
+        self.set_default(self.default_rows)
+        self.tableView.resizeColumnsToContents()
+        self.tableView.resizeRowsToContents()
+
+        # create and add buttons
+        self.btnLayout = QHBoxLayout()
+
+        self.addRowBtn = QPushButton('+', self)
+        self.addRowBtn.setToolTip('inserts a blank row(s) after the selected'
+                                  'row(s)')
+        self.addRowBtn.clicked.connect(self._addRow)
+        self.btnLayout.addWidget(self.addRowBtn)
+
+        self.delRowBtn = QPushButton('-', self)
+        self.delRowBtn.setToolTip('deletes the selected row(s)')
+        self.delRowBtn.clicked.connect(self._delRow)
+        self.btnLayout.addWidget(self.delRowBtn)
+
+        self.upRowBtn = QPushButton('up', self)
+        self.upRowBtn.setToolTip('move currently selected row down')
+        self.upRowBtn.clicked.connect(self._upRow)
+        self.btnLayout.addWidget(self.upRowBtn)
+
+        self.downRowBtn = QPushButton('down', self)
+        self.downRowBtn.setToolTip('move currently selected row down')
+        self.downRowBtn.clicked.connect(self._downRow)
+        self.btnLayout.addWidget(self.downRowBtn)
+
+        # create the layout and add the widgets
+        self.mainLayout = QVBoxLayout()
+        self.mainLayout.addWidget(self.mainLabel)
+        self.mainLayout.addWidget(self.tableView)
+        self.mainLayout.addLayout(self.btnLayout)
+        self.setLayout(self.mainLayout)
+
+    def get_parameters(self):
+        '''Return the entire data from the table.
+
+        Returns the entire table data as a list of dicts, with each dict being
+        a row that maps the column header to it's value. This follows the
+        ``mily.widget`` API.
+
+        '''
+        return self.tableView.get_parameters()
+
+    def set_default(self, parameters):
+        '''Sets the default values from 'parameters' to the model.
+
+        Sets the data from 'parameters' to the model, overwriting any existing
+        data in the model. This follows the ``mily.widget`` API.
+
+        Parameters
+        ----------
+        parameters : [dicts]
+            List of dicts  with each dict being a row that maps the column
+            header to it's value.
+        '''
+        self.tableView.set_default(parameters)
+
+    def _addRow(self):
+        '''inserts an empty row after the (last) currently selected row(s)'''
+
+        indices = self.tableView.selectionModel().selectedIndexes()
+        rows = [index.row() for index in indices]
+        rows.sort(reverse=True)
+        if rows:  # add an empty row after the last selected row
+            self.tableView.model().insertRow(rows[0]+1, [])
+        else:  # If no rows selected add row at end of table
+            end_row = self.tableView.model().rowCount()
+            self.tableView.model().insertRow(end_row, [])
+
+    def _delRow(self):
+        '''deletes the selected row(s)'''
+        indices = self.tableView.selectionModel().selectedIndexes()
+        rows = [index.row() for index in indices]
+        rows.sort(reverse=True)
+        if self._check_rows(rows):
+            for row in rows:
+                self.tableView.model().takeRow(row)
+
+    def _upRow(self):
+        '''Moves the currently selected row(s) up one.'''
+        indices = self.tableView.selectionModel().selectedIndexes()
+        rows = [index.row()
+                for index in indices
+                if index.row() != 0]
+        rows.sort()
+        if self._check_rows(rows):
+            for row in rows:
+                items = self.tableView.model().takeRow(row)
+                self.tableView.model().insertRow(row-1, items)
+
+    def _downRow(self):
+        '''Moves the currently selected row(s) down one.'''
+        last_row = self.tableView.model().rowCount()-1
+        indices = self.tableView.selectionModel().selectedIndexes()
+        rows = [index.row()
+                for index in indices
+                if index.row() != last_row]
+        rows.sort(reverse=True)
+        if self._check_rows(rows):
+            for row in rows:
+                items = self.tableView.model().takeRow(row)
+                self.tableView.model().insertRow(row+1, items)
+
+    def _check_rows(self, rows, only_one=False):
+        '''Checks how many items are in ``rows`` and alerts user if not right.
+
+        Checks that the number of indices in ``rows``, alerts the user with a
+        popup box if their are no items in ``rows``. Alternatively if the kwarg
+        ``only_one`` is ``True`` also alerts users that to many rows are
+        selected. Returns ``True`` if the right number(s) of items are in
+        ``rows`` otherwise it returns ``False``.
+
+        Parameters
+        ----------
+        rows : [row indices]
+            A list of row indices to be checked.
+        only_one : Bool, optional
+            A boolean that indicates if more than one row is allowed, default
+            is ``False``.
+        Returns
+        -------
+        Ok : Bool
+            A boolean to indicate if the number of items in row is Ok.
+
+        '''
+        Ok = True
+
+        if not rows:  # if no cell is selected
+            Ok = False
+            warning = QMessageBox()
+            warning.setIcon(QMessageBox.Information)
+            warning.setWindowTitle('Row(s) must be selected')
+            warning.setText('Action not performed as no row is selected')
+            warning.setDetailedText('This warning generally occurs '
+                                    'because no row is selected, select a row'
+                                    ' and try again')
+            warning.setStandardButtons(QMessageBox.Ok)
+            warning.exec_()
+
+        elif len(rows) > 1 and only_one:
+            Ok = False
+            warning = QMessageBox()
+            warning.setIcon(QMessageBox.Information)
+            warning.setWindowTitle('More than one row is selected')
+            warning.setText('Action not performed as more than one row is '
+                            'selected')
+            warning.setDetailedText('This warning generally occurs '
+                                    'because there are more than one row '
+                                    'selected, unselect some rows and try '
+                                    'again')
+            warning.setStandardButtons(QMessageBox.Ok)
+            warning.exec_()
+
+        return Ok
+
+
+class MTableInterfaceWidgetWithExport(MTableInterfaceWidget):
+    '''Extends the MTableInterfaceWidget to add export and duplicate buttons.
+
+    Extends the MTableInterfaceWidget with the addition of two buttons for
+    modifying the rows as a whole. They are:
+        duplicate: duplicates the selected row(s)
+        export: exports the selected row by calling self.functions with the
+            kwargs from the selected row. Does not work with multiple rows
+            selected.
+
+    Parameters
+    ----------
+    function : func
+        The function asociated with this table input.
+    *args/**kwargs : various
+        args and kwargs to be passed to ``PyQt5.QtWidgets.QWidget``.
+    title : str
+        The title to give the widget.
+    label_header : str
+        The header to use for the label column in the table.
+    geometry : tuple
+        The location and size of the widget given as a tuple with the values:
+        ``(left, top, width, height)``.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.duplicateRowBtn = QPushButton('duplicate', self)
+        self.duplicateRowBtn.setToolTip('inserts a duplicate of the selected '
+                                        'row(s)')
+        self.duplicateRowBtn.clicked.connect(self._duplicateRow)
+        self.btnLayout.addWidget(self.duplicateRowBtn)
+
+        self.executeBtn = QPushButton('execute', self)
+        self.executeBtn.setToolTip('executes the "function" with "kwargs" '
+                                   'from the selected row')
+        self.executeBtn.clicked.connect(self._execute)
+        self.btnLayout.addWidget(self.executeBtn)
+
+    def _duplicateRow(self):
+        '''duplicates the selected row(s) into the table after the row(s)'''
+
+        # find the selected row(s)
+        indices = self.tableView.selectionModel().selectedIndexes()
+        rows = [index.row() for index in indices]
+        rows.sort(reverse=True)
+
+        if self._check_rows(rows):
+            model = self.tableView.model()
+            for row in rows:
+                row_data = []
+                for column in range(0, model.columnCount()):
+                    value = model.item(row, column).data(Qt.DisplayRole)
+                    item = QStandardItem()
+                    item.setData(value, Qt.DisplayRole)
+                    row_data.append(item)
+                model.insertRow(row+1, row_data)
+
+    def _execute(self):
+        '''Executes the function for the selected row'''
+
+        indices = self.tableView.selectionModel().selectedIndexes()
+        rows = [index.row() for index in indices]
+
+        if self._check_rows(rows, only_one=True):
+            row = rows[0]
+            parameters = self._extract_row(row)
+            self.function(**parameters)
+
+    def _extract_row(self, row):
+        '''Returns the data associated with the row defined by 'row_num'.
+
+        Parameters
+        ----------
+        row : int
+            The row number who's data should be extracted.
+
+        Returns
+        -------
+        parameters  : dict
+            A dictionary mapping kwargs to values.
+        '''
+        column_names = list(self.editor_map.keys())
+        model = self.tableView.model()
+        parameters = {}
+        # step through each column but the first one
+        for column in range(0, model.columnCount()):
+            item = model.item(row, column)
+            parameters[column_names[column]] = item.data(Qt.DisplayRole)
+
+        return parameters

--- a/mily/table_interface_examples.py
+++ b/mily/table_interface_examples.py
@@ -1,4 +1,4 @@
-from .table_interface import MTableInterfaceWidgetWithExport
+from .table_interface import MFunctionTableInterfaceWidget
 from .widgets import MText, MComboBox, MISpin, MFSpin
 
 
@@ -29,8 +29,8 @@ def simple_function(str_var='label', selector_var='yes', float_var=1.0,
     print((str_var, selector_var, float_var, int_var))
 
 
-class SimpleFunctionWidget(MTableInterfaceWidgetWithExport):
-    '''A ``MTableInterfaceWidgetWithExport`` for use with simple_function.
+class SimpleFunctionWidget(MFunctionTableInterfaceWidget):
+    '''A ``MFunctionTableInterfaceWidget`` for use with simple_function.
 
     Adds custom ``selector_values``, ``editor_map`` and ``default_rows``
     attributes which contain some function specfic information and/or user

--- a/mily/table_interface_examples.py
+++ b/mily/table_interface_examples.py
@@ -17,7 +17,7 @@ def partialclass(cls, partial_kwargs):
 
     class PartialClass(cls):
         def __init__(self, *args, **kwargs):
-            super().__init__(*args, **partial_kwargs, **kwargs)
+            super().__init__(*args, **{**partial_kwargs, **kwargs})
     return PartialClass
 
 
@@ -49,21 +49,22 @@ class SimpleFunctionWidget(MFunctionTableInterfaceWidget):
 
     '''
 
-    # NOTE I have made these 'class' variables as I am considering
-    # that we may want to make them traitlets for user config reasons.
-    selector_values = ['yes', 'no', 'maybe']
-    default_rows = [{'str_var': 'plan_1', 'selector_var': True,
-                     'float_var': 1.1, 'int_var': 1},
-                    {'str_var': 'plan_2', 'selector_var': False,
-                     'float_var': 2.2, 'int_var': 2},
-                    {'str_var': 'plan_3', 'selector_var': None,
-                     'float_var': 3.3, 'int_var': 3}]
-
     def __init__(self, name, *args, **kwargs):
         _sel_dict = {'yes': True, 'no': False, 'maybe': None}
-        self.editor_map = {'str_var': MText,
-                           'selector_var': partialclass(MComboBox,
-                                                        {'items': _sel_dict}),
-                           'float_var': MFSpin,
-                           'int_var': MISpin}
-        super().__init__(simple_function, name, *args, **kwargs)
+        self.selector_values = list(_sel_dict.keys())
+        default_parameters = [{'str_var': 'plan_1', 'selector_var': True,
+                               'float_var': 1.1, 'int_var': 1},
+                              {'str_var': 'plan_2', 'selector_var': False,
+                               'float_var': 2.2, 'int_var': 2},
+                              {'str_var': 'plan_3', 'selector_var': None,
+                               'float_var': 3.3, 'int_var': 3}]
+
+        table_editor_map = {'str_var': MText,
+                            'selector_var': partialclass(MComboBox,
+                                                         {'items': _sel_dict}),
+                            'float_var': MFSpin,
+                            'int_var': MISpin}
+        super().__init__(simple_function, name, *args,
+                         table_editor_map=table_editor_map,
+                         default_parameters=[{}, *default_parameters, {}],
+                         **kwargs)

--- a/mily/table_interface_examples.py
+++ b/mily/table_interface_examples.py
@@ -1,0 +1,129 @@
+from .table_interface import MTableInterfaceWidgetWithExport
+from .widgets import MText, MComboBox, MISpin, MFSpin
+from bluesky.plans import scan
+from bluesky.simulators import summarize_plan
+from ophyd.sim import hw
+
+hw = hw()
+
+
+def partialclass(cls, partial_kwargs):
+    '''Returns a partial class with 'partial_kwargs' values set
+
+
+    This function returns a class whereby any args/kwargs in the dictionary
+    ``partial_kwargs`` are set.
+
+    Parameters
+    ----------
+    partial_kwargs : dict
+        a dict mapping arg/kwarg parameters to values.
+    '''
+
+    class PartialClass(cls):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **partial_kwargs, **kwargs)
+    return PartialClass
+
+
+# simplest possible tableInterface GUI example
+def simple_function(str_var='label', selector_var='yes', float_var=1.0,
+                    int_var=2):
+    '''A simple function that prints its arguments as a tuple.'''
+
+    print((str_var, selector_var, float_var, int_var))
+
+
+class SimpleFunctionWidget(MTableInterfaceWidgetWithExport):
+    '''A ``MTableInterfaceWidgetWithExport`` for use with simple_function.
+
+    Adds custom ``selector_values``, ``editor_map`` and ``default_rows``
+    attributes which contain some function specfic information and/or user
+    configurable information.
+
+    To run this example as a standalone window use the following:
+
+    ..code-block:: python
+
+        from mily.table_interface_examples import SimplefunctionWidget
+        from PyQt5.QtWidgets import QApplication
+        app = QApplication([])
+        window = SimplefunctionWidget('simple_function')
+        window.show()
+        app.exec_()
+
+    '''
+
+    # NOTE I have made these 'class' variables as I am considering
+    # that we may want to make them traitlets for user config reasons.
+    selector_values = ['yes', 'no', 'maybe']
+    default_rows = [{'str_var': 'plan_1', 'selector_var': True,
+                     'float_var': 1.1, 'int_var': 1},
+                    {'str_var': 'plan_2', 'selector_var': False,
+                     'float_var': 2.2, 'int_var': 2},
+                    {'str_var': 'plan_3', 'selector_var': None,
+                     'float_var': 3.3, 'int_var': 3}]
+
+    def __init__(self, name, *args, **kwargs):
+        _sel_dict = {'yes': True, 'no': False, 'maybe': None}
+        self.editor_map = {'str_var': MText,
+                           'selector_var': partialclass(MComboBox,
+                                                        {'items': _sel_dict}),
+                           'float_var': MFSpin,
+                           'int_var': MISpin}
+        super().__init__(simple_function, name, *args, **kwargs)
+
+
+# simplest possible tableinterface RunEngine GUI example
+def simple_REfunction(label='label', det=hw.det, motor=hw.motor, start=0,
+                      stop=3, num_steps=3):
+    '''A simple function that can performs summarize_plan on a scan plan.'''
+
+    plan = scan([det], motor, start, stop, num_steps, md={'plan_label': label})
+    summarize_plan(plan)
+
+
+class SimpleREfunctionWidget(MTableInterfaceWidgetWithExport):
+    '''A ``MTableInterfaceWidgetWithExport`` for use with simple_REfunction.
+
+    Adds custom ``detectors``, ``motors``, ``editor_map`` and ``default_rows``
+    attributes which contain some function specfic information and/or user
+    configurable information.
+
+   To run this example as a standalone window use the following:
+
+    ..code-block:: python
+
+        from bluesky_ui.table_interface_examples import SimpleREfunctionWidget
+        from PyQt5.QtWidgets import QApplication
+        app = QApplication([])
+        window = SimpleREfunctionWidget('simple_REfunction')
+        window.show()
+        app.exec_()
+
+    '''
+
+    # NOTE I have made these 'class' variables as I am considering
+    # that we may want to make them traitlets for user config reasons.
+    detectors = [hw.det, hw.det1, hw.det2]
+    motors = [hw.motor, hw.motor1, hw.motor2]
+    default_rows = [
+        {'label': 'plan_1', 'det': hw.det, 'motor': hw.motor, 'start': 0,
+         'stop': 2, 'num_steps': 3},
+        {'label': 'plan_2', 'det': hw.det1, 'motor': hw.motor1, 'start': -3,
+         'stop': 3, 'num_steps': 7},
+        {'label': 'plan_3', 'det': hw.det2, 'motor': hw.motor2, 'start': -4,
+         'stop': 4, 'num_steps': 9}]
+
+    def __init__(self, name, *args, **kwargs):
+        _det_dict = {det.name: det for det in self.detectors}
+        _motor_dict = {motor.name: motor for motor in self.motors}
+        self.editor_map = {'label': MText,
+                           'det': partialclass(MComboBox,
+                                               {'items': _det_dict}),
+                           'motor': partialclass(MComboBox,
+                                                 {'items': _motor_dict}),
+                           'start': MFSpin,
+                           'stop': MFSpin,
+                           'num_steps': MISpin}
+        super().__init__(simple_REfunction, name, *args, **kwargs)

--- a/mily/table_interface_examples.py
+++ b/mily/table_interface_examples.py
@@ -26,10 +26,10 @@ class SimpleFunctionWidget(MFunctionTableInterfaceWidget):
 
     ..code-block:: python
 
-        from mily.table_interface_examples import SimplefunctionWidget
+        from mily.table_interface_examples import SimpleFunctionWidget
         from PyQt5.QtWidgets import QApplication
         app = QApplication([])
-        window = SimplefunctionWidget('simple_function')
+        window = SimpleFunctionWidget('simple_function')
         window.show()
         app.exec_()
 

--- a/mily/table_interface_examples.py
+++ b/mily/table_interface_examples.py
@@ -1,24 +1,10 @@
 from .table_interface import MFunctionTableInterfaceWidget
+from functools import partial
 from .widgets import MText, MComboBox, MISpin, MFSpin
 
-
-def partialclass(cls, partial_kwargs):
-    '''Returns a partial class with 'partial_kwargs' values set
-
-
-    This function returns a class whereby any args/kwargs in the dictionary
-    ``partial_kwargs`` are set.
-
-    Parameters
-    ----------
-    partial_kwargs : dict
-        a dict mapping arg/kwarg parameters to values.
-    '''
-
-    class PartialClass(cls):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **{**partial_kwargs, **kwargs})
-    return PartialClass
+def mcombobox_factory(name, items, parent, **kwargs):
+    '''Allows functools.partial to be employed to define 'items'.'''
+    return MComboBox(name, parent=parent, items=items, **kwargs)
 
 
 # simplest possible tableInterface GUI example
@@ -60,8 +46,8 @@ class SimpleFunctionWidget(MFunctionTableInterfaceWidget):
                                'float_var': 3.3, 'int_var': 3}]
 
         table_editor_map = {'str_var': MText,
-                            'selector_var': partialclass(MComboBox,
-                                                         {'items': _sel_dict}),
+                            'selector_var': partial(mcombobox_factory,
+                                                    'items'= _sel_dict),
                             'float_var': MFSpin,
                             'int_var': MISpin}
         super().__init__(simple_function, name, *args,

--- a/mily/table_interface_examples.py
+++ b/mily/table_interface_examples.py
@@ -1,10 +1,5 @@
 from .table_interface import MTableInterfaceWidgetWithExport
 from .widgets import MText, MComboBox, MISpin, MFSpin
-from bluesky.plans import scan
-from bluesky.simulators import summarize_plan
-from ophyd.sim import hw
-
-hw = hw()
 
 
 def partialclass(cls, partial_kwargs):
@@ -72,58 +67,3 @@ class SimpleFunctionWidget(MTableInterfaceWidgetWithExport):
                            'float_var': MFSpin,
                            'int_var': MISpin}
         super().__init__(simple_function, name, *args, **kwargs)
-
-
-# simplest possible tableinterface RunEngine GUI example
-def simple_REfunction(label='label', det=hw.det, motor=hw.motor, start=0,
-                      stop=3, num_steps=3):
-    '''A simple function that can performs summarize_plan on a scan plan.'''
-
-    plan = scan([det], motor, start, stop, num_steps, md={'plan_label': label})
-    summarize_plan(plan)
-
-
-class SimpleREfunctionWidget(MTableInterfaceWidgetWithExport):
-    '''A ``MTableInterfaceWidgetWithExport`` for use with simple_REfunction.
-
-    Adds custom ``detectors``, ``motors``, ``editor_map`` and ``default_rows``
-    attributes which contain some function specfic information and/or user
-    configurable information.
-
-   To run this example as a standalone window use the following:
-
-    ..code-block:: python
-
-        from bluesky_ui.table_interface_examples import SimpleREfunctionWidget
-        from PyQt5.QtWidgets import QApplication
-        app = QApplication([])
-        window = SimpleREfunctionWidget('simple_REfunction')
-        window.show()
-        app.exec_()
-
-    '''
-
-    # NOTE I have made these 'class' variables as I am considering
-    # that we may want to make them traitlets for user config reasons.
-    detectors = [hw.det, hw.det1, hw.det2]
-    motors = [hw.motor, hw.motor1, hw.motor2]
-    default_rows = [
-        {'label': 'plan_1', 'det': hw.det, 'motor': hw.motor, 'start': 0,
-         'stop': 2, 'num_steps': 3},
-        {'label': 'plan_2', 'det': hw.det1, 'motor': hw.motor1, 'start': -3,
-         'stop': 3, 'num_steps': 7},
-        {'label': 'plan_3', 'det': hw.det2, 'motor': hw.motor2, 'start': -4,
-         'stop': 4, 'num_steps': 9}]
-
-    def __init__(self, name, *args, **kwargs):
-        _det_dict = {det.name: det for det in self.detectors}
-        _motor_dict = {motor.name: motor for motor in self.motors}
-        self.editor_map = {'label': MText,
-                           'det': partialclass(MComboBox,
-                                               {'items': _det_dict}),
-                           'motor': partialclass(MComboBox,
-                                                 {'items': _motor_dict}),
-                           'start': MFSpin,
-                           'stop': MFSpin,
-                           'num_steps': MISpin}
-        super().__init__(simple_REfunction, name, *args, **kwargs)

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -66,6 +66,42 @@ class MFSpin(QtWidgets.QDoubleSpinBox):
             self.setValue(v)
 
 
+class MComboBox(QtWidgets.QComboBox):
+    '''A ``PyQt5.QtWidgets.QComboBox`` that matches the ``mily`` syntax.
+
+    This adds ``get_parameters(self)`` and ``set_default(self,v)`` methods that
+    are common for all ``mily`` widgets to make the consumer code easier. It
+    also adds a ``name`` attribute and ``__init__`` argument.
+
+    Parameters
+    ----------
+    args: various
+        args passed to ``PyQt5.QtWidgets.QComboBox.__init__(...)``.
+    items : dict, optional
+        optional dict mapping a 'display name' to items to include in the
+        dropdown list.
+    kwargs: various
+        kwargs passed to ``pyQt5.QtWidgets.QComboBox.__init__(...)``.
+    '''
+
+    def __init__(self, name, items={}, **kwargs):
+        super().__init__(**kwargs)
+        self._name = name
+        for i, (key, val) in enumerate(items.items()):
+            self.addItem(key)
+            self.setItemData(i, val)
+
+    def get_parameters(self):
+        '''returns a ``{name: currentData}`` dictionary. '''
+        return {self._name: self.currentData()}
+
+    def set_default(self, currentData):
+        '''set ``self.currentData`` to ``currentData``.'''
+        if currentData is not None:
+            index = self.findData(currentData)
+            self.setCurrentIndex(index)
+
+
 class MDateTime(QtWidgets.QDateTimeEdit):
     def __init__(self, name, **kwargs):
         super().__init__(**kwargs)

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -69,18 +69,18 @@ class MFSpin(QtWidgets.QDoubleSpinBox):
 class MComboBox(QtWidgets.QComboBox):
     '''A ``PyQt5.QtWidgets.QComboBox`` that matches the ``mily`` syntax.
 
-    This adds ``get_parameters(self)`` and ``set_default(self,v)`` methods that
+    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods that
     are common for all ``mily`` widgets to make the consumer code easier. It
     also adds a ``name`` attribute and ``__init__`` argument.
 
     Parameters
     ----------
-    args: various
+    args : various
         args passed to ``PyQt5.QtWidgets.QComboBox.__init__(...)``.
     items : dict, optional
         optional dict mapping a 'display name' to items to include in the
         dropdown list.
-    kwargs: various
+    kwargs : various
         kwargs passed to ``pyQt5.QtWidgets.QComboBox.__init__(...)``.
     '''
 
@@ -92,11 +92,11 @@ class MComboBox(QtWidgets.QComboBox):
             self.setItemData(i, val)
 
     def get_parameters(self):
-        '''returns a ``{name: currentData}`` dictionary. '''
+        '''Returns a ``{name: currentData}`` dictionary. '''
         return {self._name: self.currentData()}
 
     def set_default(self, currentData):
-        '''set ``self.currentData`` to ``currentData``.'''
+        '''Sets ``self.currentData`` to ``currentData``.'''
         if currentData is not None:
             index = self.findData(currentData)
             self.setCurrentIndex(index)
@@ -105,16 +105,16 @@ class MComboBox(QtWidgets.QComboBox):
 class MCheckBox(QtWidgets.QCheckBox):
     '''A ``PyQt5.QtWidgets.QCheckBox`` that matches the ``mily`` syntax.
 
-    This adds ``get_parameters(self)`` and ``set_default(self,v)`` methods that
+    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods that
     are common for all ``mily`` widgets to make the consumer code easier. It
     also adds a ``name`` attribute and ``__init__`` argument.
 
     Parameters
     ----------
-    args: various
+    args : various
         args passed to ``PyQt5.QtWidgets.QCheckBox.__init__(...)``.
-    kwargs: various
-        kwargs passed to ``pyQt5.QtWidgets.QCheckBox.__init__(...)``.
+    kwargs : various
+        kwargs passed to ``PyQt5.QtWidgets.QCheckBox.__init__(...)``.
     '''
 
     def __init__(self, name, **kwargs):
@@ -122,11 +122,11 @@ class MCheckBox(QtWidgets.QCheckBox):
         self._name = name
 
     def get_parameters(self):
-        '''returns a ``{name: isChecked}`` dictionary. '''
+        '''Returns a ``{name: isChecked}`` dictionary.'''
         return {self._name: self.isChecked()}
 
     def set_default(self, checkState):
-        '''set ``self.isChecked`` to ``checkState``.'''
+        '''Sets ``self.isChecked`` to ``checkState``.'''
         if checkState is not None:
             self.setChecked(checkState)
 
@@ -134,7 +134,7 @@ class MCheckBox(QtWidgets.QCheckBox):
 class MSelector(QtWidgets.QGroupBox):
     '''A widget that displays a list of objects with 'checkboxes'.
 
-    This adds ``get_parameters(self)`` and ``set_default(self,v)`` methods that
+    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods that
     are common for all ``mily`` widgets to make the consumer code easier. It
     also adds a ``name`` attribute and ``__init__`` argument. It results in a
     vertical list of objects (defined in the 'items' arg) with a corresponding
@@ -142,15 +142,15 @@ class MSelector(QtWidgets.QGroupBox):
 
     Parameters
     ----------
-    name: str
+    name : str
         name of the widget to be stored in ``self._name``
     option_list : list
         list of items to include checkboxes for.
     vertical : bool, optional
         optional boolean that indicates if the list should be displayed
         vertically (True) or horizontally (False). default is True.
-    kwargs: various
-        kwargs passed to ``pyQt5.QtWidgets.QComboBox.__init__(...)``.
+    kwargs : various
+        kwargs passed to ``PyQt5.QtWidgets.QGroupBox.__init__(...)``.
     '''
 
     def __init__(self, name, option_list, vertical=True, **kwargs):

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -177,7 +177,7 @@ class MSelector(QtWidgets.QGroupBox):
         return {self._name: item_list}
 
     def set_default(self, value):
-        # value is a list of detectors of the form [det1, det2, ...]
+        # value is list of python values or objects.
         if value is not None:
             for button in self.button_group.buttons():
                 button.setChecked(button.item in value)

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -1,5 +1,4 @@
 from qtpy import QtWidgets
-from ophyd import Device
 import datetime
 from pyqtgraph.parametertree import parameterTypes as pTypes
 
@@ -69,9 +68,9 @@ class MFSpin(QtWidgets.QDoubleSpinBox):
 class MComboBox(QtWidgets.QComboBox):
     '''A ``PyQt5.QtWidgets.QComboBox`` that matches the ``mily`` syntax.
 
-    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods that
-    are common for all ``mily`` widgets to make the consumer code easier. It
-    also adds a ``name`` attribute and ``__init__`` argument.
+    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods
+    that are common for all ``mily`` widgets to make the consumer code easier.
+    It also adds a ``name`` attribute and ``__init__`` argument.
 
     Parameters
     ----------
@@ -105,9 +104,9 @@ class MComboBox(QtWidgets.QComboBox):
 class MCheckBox(QtWidgets.QCheckBox):
     '''A ``PyQt5.QtWidgets.QCheckBox`` that matches the ``mily`` syntax.
 
-    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods that
-    are common for all ``mily`` widgets to make the consumer code easier. It
-    also adds a ``name`` attribute and ``__init__`` argument.
+    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods
+    that are common for all ``mily`` widgets to make the consumer code easier.
+    It also adds a ``name`` attribute and ``__init__`` argument.
 
     Parameters
     ----------
@@ -134,11 +133,11 @@ class MCheckBox(QtWidgets.QCheckBox):
 class MSelector(QtWidgets.QGroupBox):
     '''A widget that displays a list of objects with 'checkboxes'.
 
-    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods that
-    are common for all ``mily`` widgets to make the consumer code easier. It
-    also adds a ``name`` attribute and ``__init__`` argument. It results in a
-    vertical list of objects (defined in the 'items' arg) with a corresponding
-    checkbox for each item. It returns a list of checked items.
+    This adds ``get_parameters(self)`` and ``set_default(self, v)`` methods
+    that are common for all ``mily`` widgets to make the consumer code easier.
+    It also adds a ``name`` attribute and ``__init__`` argument. It results in
+    a vertical list of objects (defined in the 'items' arg) with a
+    corresponding checkbox for each item. It returns a list of checked items.
 
     Parameters
     ----------
@@ -186,10 +185,7 @@ class MSelector(QtWidgets.QGroupBox):
         # value is a list of detectors of the form [det1, det2, ...]
         if value is not None:
             for button in self.button_group.buttons():
-                if button.item in value:
-                    button.setChecked(True)
-                else:
-                    button.setChecked(False)
+                button.setChecked(button.item in value)
 
 
 class MDateTime(QtWidgets.QDateTimeEdit):

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -35,7 +35,7 @@ class MText(QtWidgets.QLineEdit):
 
 
 class MISpin(QtWidgets.QSpinBox):
-    def __init__(self, name, minimum=-2**16,maximum=2**16, **kwargs):
+    def __init__(self, name, minimum=-2**16, maximum=2**16, **kwargs):
         super().__init__(minimum=minimum, maximum=maximum, **kwargs)
         self._name = name
 

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -35,8 +35,8 @@ class MText(QtWidgets.QLineEdit):
 
 
 class MISpin(QtWidgets.QSpinBox):
-    def __init__(self, name, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, name, minimum=-2**16,maximum=2**16, **kwargs):
+        super().__init__(minimum=minimum, maximum=maximum, **kwargs)
         self._name = name
 
     def get_parameters(self):
@@ -48,8 +48,8 @@ class MISpin(QtWidgets.QSpinBox):
 
 
 class MFSpin(QtWidgets.QDoubleSpinBox):
-    def __init__(self, name, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, name, minimum=-2**16, maximum=2**16, **kwargs):
+        super().__init__(minimum=minimum, maximum=maximum, **kwargs)
         self._name = name
 
     def get_parameters(self):

--- a/mily/widgets.py
+++ b/mily/widgets.py
@@ -38,8 +38,6 @@ class MISpin(QtWidgets.QSpinBox):
     def __init__(self, name, **kwargs):
         super().__init__(**kwargs)
         self._name = name
-        self.setKeyboardTracking(False)
-        self.setRange(-2**16, 2**16)
 
     def get_parameters(self):
         return {self._name: self.value()}
@@ -53,9 +51,6 @@ class MFSpin(QtWidgets.QDoubleSpinBox):
     def __init__(self, name, **kwargs):
         super().__init__(**kwargs)
         self._name = name
-        self.setDecimals(3)
-        self.setKeyboardTracking(False)
-        self.setRange(-2**16, 2**16)
 
     def get_parameters(self):
         return {self._name: self.value()}


### PR DESCRIPTION
This adds the minimally useful version of a table interface widget. A detailed background to this, and potential use- cases can be found [here](https://github.com/NSLS-II/mily/issues/12)

Essentially it maps 'kwargs' from a 'kwarg' only function to columns in a table, allowing for different sets of 'kwargs' to be 'staged'. It also adds an 'execute' button which feeds the 'kwargs' from a given row into the associated function and executes it.

Discussion about where this whole thing is heading, or potential extensions to it, should be started in [mily issue # ...](https://github.com/NSLS-II/mily/issues/12)

Here is a screen shot of what a version with random different type 'kwargs' would look like, the configuration of this can be seem in ``mily.table_interface_examples`` in this PR as well as some instructions on how to run it:
![minimally useful function](https://user-images.githubusercontent.com/25772709/63098940-0d190100-bf42-11e9-9f0c-54da85ed00cf.png)

Additionally an example use case for 'summarizing' a plan (or potentially running it) can be found in ``bluesky-ui.table_interface_examples.py``. in the PR found [here](url). here is the associated screenshot for that:

![minimally useful RE](https://user-images.githubusercontent.com/25772709/63099123-6f720180-bf42-11e9-86ed-a6d83a21613f.png)

